### PR TITLE
Test results for running gnostic-grpc on 2000+ OpenAPI v2 files

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -566,6 +566,19 @@ func getOpenAPITypesToProtoBufTypes() map[string]dpb.FieldDescriptorProto_Type {
 		"boolean": dpb.FieldDescriptorProto_TYPE_BOOL,
 		"object":  dpb.FieldDescriptorProto_TYPE_MESSAGE,
 		// Array not set: could be either scalar or non-scalar value.
+
+		// Additional values according to: https://swagger.io/docs/specification/data-models/data-types/#string
+		"date":      dpb.FieldDescriptorProto_TYPE_STRING,
+		"date-time": dpb.FieldDescriptorProto_TYPE_STRING,
+		"password":  dpb.FieldDescriptorProto_TYPE_STRING,
+		"binary":    dpb.FieldDescriptorProto_TYPE_STRING,
+		"email":     dpb.FieldDescriptorProto_TYPE_STRING,
+		"uuid":      dpb.FieldDescriptorProto_TYPE_STRING,
+		"uri":       dpb.FieldDescriptorProto_TYPE_STRING,
+		"hostname":  dpb.FieldDescriptorProto_TYPE_STRING,
+		"ipv4":      dpb.FieldDescriptorProto_TYPE_STRING,
+		"ipv6":      dpb.FieldDescriptorProto_TYPE_STRING,
+		"byte":      dpb.FieldDescriptorProto_TYPE_BYTES,
 	}
 }
 
@@ -576,6 +589,18 @@ func getOpenAPIScalarTypes() map[string]bool {
 		"integer": true,
 		"number":  true,
 		"boolean": true,
+		// Additional values according to: https://swagger.io/docs/specification/data-models/data-types/#string
+		"date":      true,
+		"date-time": true,
+		"password":  true,
+		"binary":    true,
+		"email":     true,
+		"uuid":      true,
+		"uri":       true,
+		"hostname":  true,
+		"ipv4":      true,
+		"ipv6":      true,
+		"byte":      true,
 	}
 }
 

--- a/generator/testfiles/api-guru/README.md
+++ b/generator/testfiles/api-guru/README.md
@@ -1,74 +1,85 @@
-Command to find OpenAPI 3.0 descriptions inside [APIs-guru/openapi-directory](https://github.com/APIs-guru/openapi-directory):
+## OpenAPI v3
+Command to find OpenAPI v3 descriptions inside [APIs-guru/openapi-directory](https://github.com/APIs-guru/openapi-directory):
     
      find . -name "openapi.yaml" -exec gnostic --grpc-out=. {} \;
-     
- Note:
- gnostic reading error: Gnostic throws an error while converting the .yaml to Proto Bufs. We see that as long as gnostic
- converts the OpenAPI description, the plugin gnostic-grpc works (with the improved surface model; see PR).
 
-| API                                       | Status:                                       | Description |
-| ------------------------------------------|:---------------------------------------------:|:---------------------------------------------:|
-| ./APIs/namsor.com/2.0.5/openapi.yaml                          | OK                        ||
-| ./APIs/bunq.com/1.0/openapi.yaml                              | gnostic reading error         | 
-| ./APIs/ip2location.com/geolocation/1.0/openapi.yaml           | OK                        | 
-| ./APIs/linode.com/4.0.15/openapi.yaml                         | gnostic reading error         | 
-| ./APIs/geodatasource.com/1.0/openapi.yaml                     | OK                        | 
-| ./APIs/ipinfodb.com/1.0/openapi.yaml                          | OK                        | 
-| ./APIs/patrowl.local/1.0.0/openapi.yaml                       | OK                        | 
-| ./APIs/cpy.re/peertube/1.3.1/openapi.yaml                     | gnostic reading error         | 
-| ./APIs/twitter.com/labs/1.1/openapi.yaml                      | gnostic reading error     | OK after removing line 1051 inside yaml file | 
-| ./APIs/api2pdf.com/1.0.0/openapi.yaml                         | OK                        | 
-| ./APIs/exchangerate-api.com/4/openapi.yaml                    | OK                        | 
-| ./APIs/bclaws.ca/bclaws/1.0.0/openapi.yaml                    | OK                        | 
-| ./APIs/getthedata.com/bng2latlong/1.0/openapi.yaml            | OK                        | 
-| ./APIs/gov.bc.ca/jobposting/1.0.0/openapi.yaml                | OK                        | 
-| ./APIs/gov.bc.ca/bcgnws/3.x.x/openapi.yaml                    | OK                        | 
-| ./APIs/gov.bc.ca/news/1.0/openapi.yaml                        | OK                        | 
-| ./APIs/gov.bc.ca/gwells/v1/openapi.yaml                       | OK                        | 
-| ./APIs/gov.bc.ca/open511/1.0.0/openapi.yaml                   | OK                        | 
-| ./APIs/gov.bc.ca/bcdc/3.0.1/openapi.yaml                      | OK                        | 
-| ./APIs/gov.bc.ca/geocoder/2.0.0/openapi.yaml                  | OK                        | 
-| ./APIs/gov.bc.ca/geomark/4.1.2/openapi.yaml                   | OK                        | 
-| ./APIs/gov.bc.ca/router/2.0.0/openapi.yaml                    | OK                        | 
-| ./APIs/box.com/2.0/openapi.yaml                               | OK                        | | 
-| ./APIs/departureboard.io/1.0/openapi.yaml                     | OK                        | 
-| ./APIs/openlinksw.com/osdb/1.0.0/openapi.yaml                 | OK                        | 
-| ./APIs/bbc.com/1.0.0/openapi.yaml                             | OK                        | | 
-| ./APIs/whatsapp.local/1.0/openapi.yaml                        | OK                        | 
-| ./APIs/vimeo.com/3.4/openapi.yaml                             | OK                        | 
-| ./APIs/mailboxvalidator.com/checker/1.0.0/openapi.yaml        | OK                        | 
-| ./APIs/mailboxvalidator.com/disposable/1.0.0/openapi.yaml     | OK                        | 
-| ./APIs/mailboxvalidator.com/validation/0.1/openapi.yaml       | OK                        | 
-| ./APIs/ably.io/1.1.0/openapi.yaml                             | OK                        | |          
-| ./APIs/listennotes.com/2.0/openapi.yaml                       | OK                        | 
-| ./APIs/fraudlabspro.com/fraud-detection/1.1/openapi.yaml      | OK                        | 
-| ./APIs/fraudlabspro.com/sms-verification/1.0/openapi.yaml     | OK                        | 
-| ./APIs/bbci.co.uk/1.0/openapi.yaml                            | OK                        |   
-| ./APIs/mashape.com/football-prediction/2/openapi.yaml         | OK                        | |
-|./APIs/tomtom.com/maps/1.0.0/openapi.yaml                      | OK                        | 
-|./APIs/tomtom.com/search/1.0.0/openapi.yaml                    | gnostic reading error         | 
-|./APIs/tomtom.com/routing/1.0.0/openapi.yaml                   | OK                        | |
-|./APIs/ip2proxy.com/1.0/openapi.yaml                           | OK                        | 
-|./APIs/brex.io/1.0.0/openapi.yaml                              | OK                        | |
-|./APIs/adyen.com/AccountService/4/openapi.yaml                 | gnostic reading error         | 
-|./APIs/adyen.com/AccountService/3/openapi.yaml                 | gnostic reading error         | 
-|./APIs/adyen.com/AccountService/5/openapi.yaml                 | gnostic reading error         | 
-|./APIs/adyen.com/PayoutService/30/openapi.yaml                 | gnostic reading error         | 
-|./APIs/adyen.com/PaymentService/30/openapi.yaml                | gnostic reading error         | 
-|./APIs/adyen.com/PaymentService/46/openapi.yaml                | gnostic reading error         | 
-|./APIs/adyen.com/PaymentService/40/openapi.yaml                | gnostic reading error         | 
-|./APIs/adyen.com/PaymentService/25/openapi.yaml                | gnostic reading error         | 
-|./APIs/adyen.com/FundService/3/openapi.yaml                    | gnostic reading error         | 
-|./APIs/adyen.com/FundService/5/openapi.yaml                    | gnostic reading error         | 
-|./APIs/adyen.com/CheckoutService/32/openapi.yaml               | gnostic reading error         | 
-|./APIs/adyen.com/CheckoutService/31/openapi.yaml               | gnostic reading error         | 
-|./APIs/adyen.com/CheckoutService/30/openapi.yaml               | gnostic reading error         | 
-|./APIs/adyen.com/CheckoutService/37/openapi.yaml               | gnostic reading error         | 
-|./APIs/adyen.com/CheckoutService/46/openapi.yaml               | gnostic reading error         | 
-|./APIs/adyen.com/CheckoutService/41/openapi.yaml               | gnostic reading error         | 
-|./APIs/adyen.com/CheckoutService/40/openapi.yaml               | gnostic reading error         | 
-|./APIs/adyen.com/NotificationConfigurationService/1/openapi.yaml| gnostic reading error         | 
-|./APIs/adyen.com/CheckoutUtilityService/1/openapi.yaml         | OK                        | 
-|./APIs/adyen.com/RecurringService/18/openapi.yaml              | gnostic reading error          | 
-|./APIs/adyen.com/RecurringService/25/openapi.yaml              | gnostic reading error          | 
-|./APIs/microsoft.com/graph/1.0.1/openapi.yaml                  | OK                        | |
+|APIs                                               | Success       | gnostic fails  | gnostic-grpc fails |
+| --------------------------------------------------|:-------------:|:--------------:|:------------------:|
+| All APIs inside: APIs-guru/openapi-directory/APIs/| 39            | 25             |0|
+
+### gnostic fails:
+Gnostic throws an error while converting the .yaml to Proto Bufs. We see that as long as gnostic converts the OpenAPI 
+description, the plugin gnostic-grpc works.
+
+./APIs/bunq.com/1.0/openapi.yaml  
+./APIs/linode.com/4.0.15/openapi.yaml  
+./APIs/cpy.re/peertube/1.3.1/openapi.yaml  
+./APIs/twitter.com/labs/1.1/openapi.yaml  
+./APIs/tomtom.com/search/1.0.0/openapi.yaml  
+./APIs/adyen.com/AccountService/4/openapi.yaml   
+./APIs/adyen.com/AccountService/3/openapi.yaml   
+./APIs/adyen.com/AccountService/5/openapi.yaml   
+./APIs/adyen.com/PayoutService/30/openapi.yaml   
+./APIs/adyen.com/PaymentService/30/openapi.yaml   
+./APIs/adyen.com/PaymentService/46/openapi.yaml   
+./APIs/adyen.com/PaymentService/40/openapi.yaml   
+./APIs/adyen.com/PaymentService/25/openapi.yaml   
+./APIs/adyen.com/FundService/3/openapi.yaml   
+./APIs/adyen.com/FundService/5/openapi.yaml   
+./APIs/adyen.com/CheckoutService/32/openapi.yaml   
+./APIs/adyen.com/CheckoutService/31/openapi.yaml   
+./APIs/adyen.com/CheckoutService/30/openapi.yaml   
+./APIs/adyen.com/CheckoutService/37/openapi.yaml   
+./APIs/adyen.com/CheckoutService/46/openapi.yaml   
+./APIs/adyen.com/CheckoutService/41/openapi.yaml   
+./APIs/adyen.com/CheckoutService/40/openapi.yaml   
+./APIs/adyen.com/NotificationConfigurationService/1/openapi.yaml   
+./APIs/adyen.com/RecurringService/18/openapi.yaml
+./APIs/adyen.com/RecurringService/25/openapi.yaml
+
+### gnostic-grpc fails:
+None  
+
+## OpenAPI v2
+Command to find OpenAPI v2 descriptions inside [APIs-guru/openapi-directory](https://github.com/APIs-guru/openapi-directory):
+    
+     find . -name "swagger.yaml" -exec gnostic --grpc-out=. {} \;
+     
+|APIs                                               | Success       | gnostic fails  | gnostic-grpc fails |
+| --------------------------------------------------|:-------------:|:--------------:|:------------------:|
+| All APIs inside: APIs-guru/openapi-directory/APIs/| 2461          | 3              |208|
+| APIs-guru/openapi-directory/APIs/azure.com/       | 1452          | 0              |207|
+| Every folder except azure.com                     | 1009          | 3              |1|
+
+### gnostic fails:
+./APIs/slack.com/1.2.0/swagger.yaml  
+./APIs/bungie.net/2.0.0/swagger.yaml  
+./APIs/rebilly.com/2.1/swagger.yaml  
+
+### gnostic-grpc fails:
+
+####azure.com   
+Most of the 207 azure APIs seem to fail, because of following error:
+
+**Example API:** ./APIs/azure.com/network-networkSecurityGroup/2017-06-01/swagger.yaml  
+**Example line inside swagger.yaml:** 1754  
+**Planning to fix:** No  
+**Error description:**
+        
+    A reference to another file that is not at the corresponding location. 
+    
+    Example: having a ref like: $ref: './virtualNetwork.json#/definitions/Subnet' (line 1754)
+    results in an error thrown by the plugin, because the mentioned file is not there (virtualNetwork.json)
+    
+#### Every folder except azure.com
+Only one API is failing:  
+
+**Example API:** ./APIs/twinehealth.com/v7.78.1/swagger.yaml  
+**Example line inside swagger.yaml:** 3088  
+**Planning to fix:** No  
+**Error description:**
+
+    A reference to the properties of an object.
+        
+    Example: Having a ref like: $ref: '#/definitions/CalendarEventResource/properties/type' (line 3088)
+    results in an error thrown by the plugin, because it is not possible to reference properties of definitions.

--- a/generator/testfiles/errors/cyclic_dependency_1.yaml
+++ b/generator/testfiles/errors/cyclic_dependency_1.yaml
@@ -12,7 +12,7 @@ paths:
       operationId: testCyclicDependency
       responses:
         200:
-          $ref: https://raw.githubusercontent.com/LorenzHW/gnostic-grpc/issue-4/generator/testfiles/errors/cyclic_dependency_2.yaml#/components/responses/Response
+          $ref: https://raw.githubusercontent.com/googleapis/gnostic-grpc/master/generator/testfiles/errors/cyclic_dependency_2.yaml#/components/responses/Response
 components:
   schemas:
     Person:

--- a/generator/testfiles/errors/cyclic_dependency_2.yaml
+++ b/generator/testfiles/errors/cyclic_dependency_2.yaml
@@ -20,4 +20,4 @@ components:
       content:
         application/json:
           schema:
-            $ref: 'https://raw.githubusercontent.com/LorenzHW/gnostic-grpc/issue-4/generator/testfiles/errors/cyclic_dependency_1.yaml#/components/schemas/Person'
+            $ref: 'https://raw.githubusercontent.com/googleapis/gnostic-grpc/master/generator/testfiles/errors/cyclic_dependency_1.yaml#/components/schemas/Person'

--- a/generator/testfiles/other.yaml
+++ b/generator/testfiles/other.yaml
@@ -16,12 +16,12 @@ paths:
       operationId: testExternalReference
       responses:
         200:
-          $ref: https://raw.githubusercontent.com/LorenzHW/gnostic-grpc/master/generator/testfiles/responses.yaml#/components/responses/Response
+          $ref: https://raw.githubusercontent.com/googleapis/gnostic-grpc/master/generator/testfiles/responses.yaml#/components/responses/Response
   /testExternalReference2:
     get:
       operationId: testExernalReference2
       parameters: #TODO: This gets rendered as body parameter, cuz of default position: POSITION_BODY
-        - $ref: https://raw.githubusercontent.com/LorenzHW/gnostic-grpc/master/generator/testfiles/parameters.yaml#/components/parameters/Parameter2
+        - $ref: https://raw.githubusercontent.com/googleapis/gnostic-grpc/master/generator/testfiles/parameters.yaml#/components/parameters/Parameter2
       responses:
         200:
           description: success


### PR DESCRIPTION
- Test results for running gnostic-grpc on 2000+ OpenAPI v2 files

- Minor improvements to generator in order to recognize a more diverse input

- Changing deprecated URLs to new domain
