### PR TITLE
Fix a few problems with generated names.

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -256,6 +256,7 @@ func buildServiceFromMethods(descr *dpb.FileDescriptorProto, renderer *Renderer)
 			return err
 		}
 
+		method.Name = cleanName(method.Name)
 		method.ParametersTypeName = cleanTypeName(method.ParametersTypeName)
 		method.ResponsesTypeName = cleanTypeName(method.ResponsesTypeName)
 		method.ParametersTypeName = strings.Title(method.ParametersTypeName)
@@ -613,6 +614,7 @@ func setMessageDescriptorName(messageDescriptorProto *dpb.DescriptorProto, name 
 // Removes characters which are not allowed for message names or field names inside .proto files.
 func cleanName(name string) string {
 	name = convertStatusCodes(name)
+	name = strings.Replace(name, ".", "_", -1)
 	name = strings.Replace(name, "-", "_", -1)
 	name = strings.Replace(name, " ", "", -1)
 	name = strings.Replace(name, "(", "", -1)

--- a/generator/main.go
+++ b/generator/main.go
@@ -78,7 +78,7 @@ func RunProtoGenerator() {
 // error if path can't be resolved or resolves to an invalid package name.
 func resolvePackageName(p string) (string, error) {
 	p, err := filepath.Abs(p)
-	p = strings.ReplaceAll(p, "-", "_")
+	p = strings.Replace(p, "-", "_", -1)
 	if err == nil {
 		p = filepath.Base(p)
 		_, err = format.Source([]byte("package " + p))

--- a/generator/main.go
+++ b/generator/main.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"go/format"
 	"path/filepath"
+	"strings"
 
 	"github.com/golang/protobuf/proto"
 	openapiv3 "github.com/googleapis/gnostic/OpenAPIv3"
@@ -32,8 +33,13 @@ func RunProtoGenerator() {
 	env.RespondAndExitIfError(err)
 
 	fileName := env.Request.SourceName
-	extension := filepath.Ext(fileName)
-	fileName = fileName[0 : len(fileName)-len(extension)]
+	for {
+		extension := filepath.Ext(fileName)
+		if extension == "" {
+			break
+		}
+		fileName = fileName[0 : len(fileName)-len(extension)]
+	}
 
 	packageName, err := resolvePackageName(fileName)
 	env.RespondAndExitIfError(err)
@@ -72,6 +78,7 @@ func RunProtoGenerator() {
 // error if path can't be resolved or resolves to an invalid package name.
 func resolvePackageName(p string) (string, error) {
 	p, err := filepath.Abs(p)
+	p = strings.ReplaceAll(p, "-", "_")
 	if err == nil {
 		p = filepath.Base(p)
 		_, err = format.Source([]byte("package " + p))


### PR DESCRIPTION
After testing with various sample API descriptions, problems arose with dashes and dots in names. Also, in some cases files were names with multiple extensions (e.g. myapi.swagger.yaml). This commit fixes the observed problems by adding a few more substitutions to the "name cleaning" helpers and by removing all extensions from file names before they are used as package names.