### PR TITLE
Resolving name collisions between gRPC service and messages + removing unnecessary imports

### DIFF
--- a/generator/generator.go
+++ b/generator/generator.go
@@ -222,7 +222,7 @@ func buildMessagesFromTypes(descr *dpb.FileDescriptorProto, renderer *Renderer) 
 			// Maps are represented as nested types inside of the descriptor.
 			if f.Kind == surface_v1.FieldKind_MAP {
 				if strings.Contains(f.Type, "map[string][]") {
-					// Not supported for now: https://github.com/LorenzHW/gnostic-grpc/issues/3#issuecomment-509348357
+					// Not supported for now: https://github.com/LorenzHW/gnostic-grpc-deprecated/issues/3#issuecomment-509348357
 					continue
 				}
 				mapDescriptorProto := buildMapDescriptorProto(f)


### PR DESCRIPTION
Fixes #7 and #8 

For #7 we try out following service names:  Foo, FooService, FooService1, FooService2 etc. until we found a valid name.